### PR TITLE
Support the addition of a query scope

### DIFF
--- a/config/statamic-scheduled-cache-invalidator.php
+++ b/config/statamic-scheduled-cache-invalidator.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    // if you want to add to the entry query specify the name of a query scope
+    // you have defined here. the scope will received the collection in its $values
+    'query_scope' => null,
+
+];

--- a/config/statamic-scheduled-cache-invalidator.php
+++ b/config/statamic-scheduled-cache-invalidator.php
@@ -2,8 +2,10 @@
 
 return [
 
-    // if you want to add to the entry query specify the name of a query scope
-    // you have defined here. the scope will received the collection in its $values
-    'query_scope' => null,
+    'query_scopes' => [
+        // collection_handle => \Path\To\Scope::class,
+        // or
+        // 'all' => \Path\To\Scope::class,
+    ],
 
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,7 +4,6 @@ namespace MityDigital\StatamicScheduledCacheInvalidator;
 
 use MityDigital\StatamicScheduledCacheInvalidator\Console\Commands\RunCommand;
 use Statamic\Providers\AddonServiceProvider;
-use Statamic\StaticCaching\Invalidator;
 
 class ServiceProvider extends AddonServiceProvider
 {
@@ -14,8 +13,14 @@ class ServiceProvider extends AddonServiceProvider
 
     public function bootAddon()
     {
-        $invalidator = app(Invalidator::class);
-        //dd($invalidator);
-        parent::bootAddon();
+        $this->mergeConfigFrom(__DIR__.'/../config/statamic-scheduled-cache-invalidator.php', 'statamic-scheduled-cache-invalidator');
+
+        if ($this->app->runningInConsole()) {
+
+            $this->publishes([
+                __DIR__.'/../config/statamic-scheduled-cache-invalidator.php' => config_path('statamic-scheduled-cache-invalidator.php'),
+            ], 'statamic-scheduled-cache-invalidator');
+
+        }
     }
 }

--- a/src/Support/ScheduledCacheInvalidator.php
+++ b/src/Support/ScheduledCacheInvalidator.php
@@ -26,8 +26,8 @@ class ScheduledCacheInvalidator
                     ->where(function ($query) use ($collection, $now) {
                         $query->whereTime($collection->sortField() ?? 'date', $now);
 
-                        if ($scope = config('statamic-scheduled-cache-invalidator.query_scope')) {
-                            $query->{$scope}($collection, $now);
+                        if ($scope = config('statamic-scheduled-cache-invalidator.query_scopes.'.$collection->handle(), config('statamic-scheduled-cache-invalidator.query_scopes.all'))) {
+                            app($scope)->apply($query, ['collection' => $collection, 'now' => $now]);
                         }
                     })
                     ->get();

--- a/src/Support/ScheduledCacheInvalidator.php
+++ b/src/Support/ScheduledCacheInvalidator.php
@@ -25,7 +25,7 @@ class ScheduledCacheInvalidator
                     ->where('published', true)
                     ->where(function ($query) use ($collection, $now) {
                         $query->whereTime($collection->sortField() ?? 'date', $now);
-                        
+
                         if ($scope = config('statamic-scheduled-cache-invalidator.query_scope')) {
                             $query->{$scope}($collection, $now);
                         }

--- a/src/Support/ScheduledCacheInvalidator.php
+++ b/src/Support/ScheduledCacheInvalidator.php
@@ -23,7 +23,13 @@ class ScheduledCacheInvalidator
                 $entries = Entry::query()
                     ->where('collection', $collection->handle())
                     ->where('published', true)
-                    ->whereTime($collection->sortField() ?? 'date', $now)
+                    ->where(function ($query) use ($collection, $now) {
+                        $query->whereTime($collection->sortField() ?? 'date', $now);
+                        
+                        if ($scope = config('statamic-scheduled-cache-invalidator.query_scope')) {
+                            $query->{$scope}($collection, $now);
+                        }
+                    })
                     ->get();
 
                 // this triggers any publish status changes in the stache

--- a/tests/Support/ScheduledCacheInvalidatorTest.php
+++ b/tests/Support/ScheduledCacheInvalidatorTest.php
@@ -2,7 +2,9 @@
 
 use MityDigital\StatamicScheduledCacheInvalidator\Support\ScheduledCacheInvalidator;
 
+use Mockery\MockInterface;
 use function Spatie\PestPluginTestTime\testTime;
+use Statamic\Query\Scopes\Scope;
 
 it('correctly gets an entry when time is disabled for the collection', function () {
     // get the support
@@ -62,3 +64,29 @@ it('does not return entried from an undated collection', function () {
     // should have nothing returned - it's not dated
     expect($support->getEntries())->toHaveCount(0);
 });
+
+it('supports query scopes', function () {
+    // get the support
+    $support = app(ScheduledCacheInvalidator::class);
+
+    // freeze time to be ON publish - this is when the undated entry has a "date" param
+    testTime()->freeze('2023-12-07 00:00:00');
+    
+    app('statamic.scopes')[TestScope::handle()] = TestScope::class;
+    
+    config()->set('statamic-scheduled-cache-invalidator.query_scope', 'test_scope');
+    
+    $this->partialMock(TestScope::class, function (MockInterface $mock) {
+        $mock->shouldReceive('apply')->once();
+    });
+
+    // should have nothing returned - it's not dated
+    expect($support->getEntries())->toHaveCount(0);
+});
+
+class TestScope extends Scope
+{
+    public function apply($query, $params)
+    {
+    }
+}

--- a/tests/Support/ScheduledCacheInvalidatorTest.php
+++ b/tests/Support/ScheduledCacheInvalidatorTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use MityDigital\StatamicScheduledCacheInvalidator\Support\ScheduledCacheInvalidator;
-
 use Mockery\MockInterface;
-use function Spatie\PestPluginTestTime\testTime;
 use Statamic\Query\Scopes\Scope;
+
+use function Spatie\PestPluginTestTime\testTime;
 
 it('correctly gets an entry when time is disabled for the collection', function () {
     // get the support
@@ -71,11 +71,11 @@ it('supports query scopes', function () {
 
     // freeze time to be ON publish - this is when the undated entry has a "date" param
     testTime()->freeze('2023-12-07 00:00:00');
-    
+
     app('statamic.scopes')[TestScope::handle()] = TestScope::class;
-    
+
     config()->set('statamic-scheduled-cache-invalidator.query_scope', 'test_scope');
-    
+
     $this->partialMock(TestScope::class, function (MockInterface $mock) {
         $mock->shouldReceive('apply')->once();
     });

--- a/tests/Support/ScheduledCacheInvalidatorTest.php
+++ b/tests/Support/ScheduledCacheInvalidatorTest.php
@@ -72,12 +72,10 @@ it('supports query scopes', function () {
     // freeze time to be ON publish - this is when the undated entry has a "date" param
     testTime()->freeze('2023-12-07 00:00:00');
 
-    app('statamic.scopes')[TestScope::handle()] = TestScope::class;
-
-    config()->set('statamic-scheduled-cache-invalidator.query_scope', 'test_scope');
+    config()->set('statamic-scheduled-cache-invalidator.query_scopes.all', TestScope::class);
 
     $this->partialMock(TestScope::class, function (MockInterface $mock) {
-        $mock->shouldReceive('apply')->once();
+        $mock->shouldReceive('apply')->times(2);
     });
 
     // should have nothing returned - it's not dated

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -68,7 +68,7 @@ abstract class TestCase extends OrchestraTestCase
         foreach ($configs as $config) {
             $app['config']->set(
                 "statamic.$config",
-                require(__DIR__."/../vendor/statamic/cms/config/{$config}.php")
+                require (__DIR__."/../vendor/statamic/cms/config/{$config}.php")
             );
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -68,7 +68,7 @@ abstract class TestCase extends OrchestraTestCase
         foreach ($configs as $config) {
             $app['config']->set(
                 "statamic.$config",
-                require (__DIR__."/../vendor/statamic/cms/config/{$config}.php")
+                require(__DIR__."/../vendor/statamic/cms/config/{$config}.php")
             );
         }
 


### PR DESCRIPTION
Requires https://github.com/statamic/cms/pull/5927

This PR adds a config `statamic-scheduled-cache-invalidator.query_scope` that accepts a snake cased query scope defined by the developer. This allows the query to be extended with other conditions, for example an end date.

The query scope receives both `collection` and `now` in the values param, which it may use to determine what restrictions to place.