### PR TITLE
Change query to also query date, not just time

### DIFF
--- a/src/Support/ScheduledCacheInvalidator.php
+++ b/src/Support/ScheduledCacheInvalidator.php
@@ -25,7 +25,7 @@ class ScheduledCacheInvalidator
                     ->where('collection', $collection->handle())
                     ->where('published', true)
                     ->where(function ($query) use ($collection, $now) {
-                        $query->whereTime($collection->sortField() ?? 'date', $now);
+                        $query->where(fn ($query) => $query->whereDate($collection->sortField() ?? 'date', $now)->whereTime($collection->sortField() ?? 'date', $now));
 
                         // what scope do we want to use?
                         $scope = config('statamic-scheduled-cache-invalidator.query_scopes', null);

--- a/src/Support/ScheduledCacheInvalidator.php
+++ b/src/Support/ScheduledCacheInvalidator.php
@@ -13,7 +13,7 @@ class ScheduledCacheInvalidator
     public function getEntries(): \Illuminate\Support\Collection
     {
         // what is "now"? how existential...
-        $now = Carbon::now()->format('Y-m-d H:i');
+        $now = Carbon::now();
 
         // get the entries inside a dated collection
         // that have a "date" (or whatever the collection is configured for)
@@ -25,7 +25,7 @@ class ScheduledCacheInvalidator
                     ->where('collection', $collection->handle())
                     ->where('published', true)
                     ->where(function ($query) use ($collection, $now) {
-                        $query->where(fn ($query) => $query->whereDate($collection->sortField() ?? 'date', $now)->whereTime($collection->sortField() ?? 'date', $now));
+                        $query->where(fn ($query) => $query->whereDate($collection->sortField() ?? 'date', $now->format('Y-m-d'))->whereTime($collection->sortField() ?? 'date', $now->format('H:i:s')));
 
                         // what scope do we want to use?
                         $scope = config('statamic-scheduled-cache-invalidator.query_scopes', null);

--- a/tests/Support/ScheduledCacheInvalidatorTest.php
+++ b/tests/Support/ScheduledCacheInvalidatorTest.php
@@ -45,8 +45,21 @@ it('correctly gets an entry when time is enabled for the collection', function (
     $entries = $support->getEntries();
 
     // should have 1, and the "dated_and_timed" collection
-    expect($entries)->toHaveCount(1)
-        ->and($entries->first()->collection()->handle())->toBe('dated_and_timed');
+    expect($entries)
+        ->toHaveCount(1)
+        ->and($entries->first()->collection()->handle())
+        ->toBe('dated_and_timed');
+
+    // freeze time to be ON publish, but an earlier day
+    testTime()->freeze('2023-12-14 11:56:00');
+
+    $entries = $support->getEntries();
+
+    // should have 1, and the "dated_and_timed_other" collection (same time, different day)
+    expect($entries)
+        ->toHaveCount(1)
+        ->and($entries->first()->collection()->handle())
+        ->toBe('dated_and_timed_other');
 
     // freeze time to be AFTER publish
     testTime()->freeze('2023-12-15 11:57:00');
@@ -54,7 +67,7 @@ it('correctly gets an entry when time is enabled for the collection', function (
     expect($support->getEntries())->toHaveCount(0);
 });
 
-it('does not return entried from an undated collection', function () {
+it('does not return entries from an undated collection', function () {
     // get the support
     $support = app(ScheduledCacheInvalidator::class);
 
@@ -75,7 +88,7 @@ it('supports query scopes', function () {
     config()->set('statamic-scheduled-cache-invalidator.query_scopes', TestScope::class);
 
     $this->partialMock(TestScope::class, function (MockInterface $mock) {
-        $mock->shouldReceive('apply')->times(2);
+        $mock->shouldReceive('apply')->times(3);
     });
 
     // should have nothing returned - it's not dated

--- a/tests/__fixtures__/blueprints/collections/dated_and_timed_other/dated_and_timed_other.yaml
+++ b/tests/__fixtures__/blueprints/collections/dated_and_timed_other/dated_and_timed_other.yaml
@@ -1,0 +1,65 @@
+title: 'Date and Time'
+tabs:
+  main:
+    display: Main
+    sections:
+      -
+        fields:
+          -
+            handle: title
+            field:
+              type: text
+              required: true
+              validate:
+                - required
+          -
+            handle: content
+            field:
+              type: markdown
+              display: Content
+              localizable: true
+          -
+            handle: author
+            field:
+              type: users
+              display: Author
+              default: current
+              localizable: true
+              max_items: 1
+          -
+            handle: template
+            field:
+              type: template
+              display: Template
+              localizable: true
+  sidebar:
+    display: Sidebar
+    sections:
+      -
+        fields:
+          -
+            handle: slug
+            field:
+              type: slug
+              localizable: true
+              validate: 'max:200'
+          -
+            handle: date
+            field:
+              type: date
+              required: true
+              default: now
+              validate:
+                - required
+              instructions_position: above
+              listable: hidden
+              visibility: visible
+              replicator_preview: true
+              mode: single
+              inline: false
+              full_width: false
+              columns: 1
+              rows: 1
+              time_enabled: true
+              time_seconds_enabled: false
+              hide_display: false

--- a/tests/__fixtures__/content/collections/dated_and_timed_other.yaml
+++ b/tests/__fixtures__/content/collections/dated_and_timed_other.yaml
@@ -1,0 +1,13 @@
+title: 'Date and Time Other'
+template: default
+layout: layout
+revisions: false
+date: true
+sort_dir: asc
+date_behavior:
+  past: public
+  future: private
+preview_targets:
+  - label: Entry
+    url: '{permalink}'
+    refresh: true

--- a/tests/__fixtures__/content/collections/dated_and_timed_other/2023-12-14-1156.dated-and-timed.md
+++ b/tests/__fixtures__/content/collections/dated_and_timed_other/2023-12-14-1156.dated-and-timed.md
@@ -1,0 +1,8 @@
+---
+id: bee8ed92-ef26-4ab6-95b3-51ac8320d415
+blueprint: dated_and_timed_other
+title: 'Dated and Timed Other'
+author: d9b0b869-8a0a-4804-96f4-fe1281ade7ea
+updated_by: d9b0b869-8a0a-4804-96f4-fe1281ade7ea
+updated_at: 1702602791
+---


### PR DESCRIPTION
This PR includes a small fix to limit the query to the date as well as the time, otherwise we will match and invalidate entries with the correct time, but on the wrong date.