### PR TITLE
Allow save method to be defined

### DIFF
--- a/config/statamic-scheduled-cache-invalidator.php
+++ b/config/statamic-scheduled-cache-invalidator.php
@@ -40,5 +40,16 @@ return [
     //         \Path\To\DifferentScope::class,
     //     ],
     // ],
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Save quietly
+    |--------------------------------------------------------------------------
+    |
+    | Do you want to save items quietly (true, so no events fired), or 
+    | not quietly (false, events will be fired)
+    |
+    */
+    'save_quietly' => true,
 
 ];

--- a/src/Console/Commands/RunCommand.php
+++ b/src/Console/Commands/RunCommand.php
@@ -46,8 +46,12 @@ class RunCommand extends Command
 
             // let's clear the cache for each Entry
             $entries->each(function (Entry $entry, $index) use ($invalidator) {
-                // invalidate magic!
-                $invalidator->invalidate($entry);
+                // if we have saved normally, invalidation has already happened
+                if (config('statamic-scheduled-cache-invalidator.save_quietly', true)) {
+
+                    // invalidate magic!
+                    $invalidator->invalidate($entry);
+                }
 
                 // progress output
                 $this->line(__('statamic-scheduled-cache-invalidator::command.entries.invalidated', [

--- a/src/Support/ScheduledCacheInvalidator.php
+++ b/src/Support/ScheduledCacheInvalidator.php
@@ -26,7 +26,7 @@ class ScheduledCacheInvalidator
                     ->get();
             })
             ->flatten()
-            ->each->saveQuietly();
+            ->each->{config('statamic-scheduled-cache-invalidator.save_quietly', true) ? 'saveQuietly' : 'save'}();
     }
 
     protected function scopes(Collection $collection): \Illuminate\Support\Collection


### PR DESCRIPTION
We have a use case where we'd like to use the console task part of the add on, but we want to allow natural invalidation to happen through the normal save method.

This PR adds a config to allow normal saving.

Theres probably an argument that you could just save() all the time and then you wouldnt need to hook into invalidation as it would happen anyway.

Anyway, happy to answer any queries or "why the heck do you need this" type questions.